### PR TITLE
Update JSON.ahk

### DIFF
--- a/JSON.ahk
+++ b/JSON.ahk
@@ -258,13 +258,12 @@ class JSON
 			for k, v in esc_char
 				StringReplace, obj, obj, % k, % v, A
 
-			while RegExMatch(obj, "[^\x20-\x7e]", ch) {
-				ustr := Asc(ch), esc_ch := "\u", n := 12
-				while (n >= 0)
-					esc_ch .= Chr((x:=(ustr>>n) & 15) + (x<10 ? 48 : 55))
-					, n -= 4
-				StringReplace, obj, obj, % ch, % esc_ch, A
-			}
+			_FormatInteger:=A_FormatInteger
+			;I don't know, how to get NumberType of SetFormat for restore later?
+			SetFormat, IntegerFast, hex
+			while RegExMatch(obj, "[^\x20-\x7e]", ch) 
+				StringReplace, obj, obj, % ch, % "\u" SubStr(Asc(ch),3), A
+			SetFormat, IntegerFast,% _FormatInteger
 			return """" . obj . """"
 		}
 		;// number


### PR DESCRIPTION
Get the **character code** in hex derectly! Only need to replace "0x" to "\u".
Much faster I think!
Test:

``` ahk
s:=0x12AB
SetFormat, IntegerFast, hex
b:=A_TickCount
    Loop 1000000{
        ;~ y:="\u",n := 12
        ;~ while(n>=0)
            ;~ y.= Chr((x:=(s>>n) & 15) + (x<10 ? 48 : 55))
            ;~ ,n-=4
        ;10438 ms

        y:="\u" SubStr(s,3)
        ;812
    }
MsgBox % A_TickCount-b
```

I don't know, how to get NumberType of SetFormat for restore later?
[My ask in fourm](http://ahkscript.org/boards/viewtopic.php?f=5&t=3910&sid=d77cc1663da120de3ec507cfab0d7b37).
