### PR TITLE
Jxon use

### DIFF
--- a/JSON.ahk
+++ b/JSON.ahk
@@ -91,8 +91,7 @@ class JSON
 				(LTrim
 				Unexpected '%ch%' -> there is no container object/array.
 				)")
-				assert := '"'
-				if (ch == ':' || !(cont is _object)), assert .= '{[tfn0123456789-'
+				assert := (cont is _object && ch == ',') ? '"' : '{["tfn0123456789-'
 			
 			} else if InStr("{[", ch) { ;// object|array - opening
 				cont := stack[1]
@@ -125,7 +124,7 @@ class JSON
 			} else if (ch >= 0 && ch <= 9) || (ch == "-") { ;// number
 				if !RegExMatch(src, "-?\d+(\.\d+)?((?i)E[-+]?\d+)?", num, pos)
 					throw Exception("Bad number", -1)
-				pos += StrLen(num.Value)-1
+				pos += num.Len()-1
 				, cont := stack[1]
 				, cont[key == dummy ? (ObjMaxIndex(cont) || 0)+1 : key] := num.Value+0
 				, assert := cont is _object ? '},' : '],'
@@ -140,16 +139,8 @@ class JSON
 				if !((tfn:=SubStr(src, pos, len:=StrLen(val))) == val)
 					throw Exception("Expected '%val%' instead of '%tfn%'")
 				pos += len-1
-				/*
-				;// advance to next char, first char has already been validated
-				while (c:=SubStr(val, A_Index+1, 1)) {
-					ch := SubStr(src, ++pos, 1)
-					if !(ch == c) ;// case-sensitive comparison
-						throw Exception("Expected '%c%' instead of %ch%")
-				}
-				*/
-				cont := stack[1]
-				, cont[key == dummy ? (ObjMaxIndex(cont) || 0)+1 : key] := Abs(%val%)
+				, cont := stack[1]
+				, cont[key == dummy ? (ObjMaxIndex(cont) || 0)+1 : key] := %val%+0
 				, assert := cont is _object ? '},' : '],'
 				if (key != dummy), key := dummy
 			}

--- a/JSON.ahk
+++ b/JSON.ahk
@@ -171,7 +171,7 @@ class JSON
 		__New(p*) {
 			ObjInsert(this, "_", [])
 			if Mod(p.MaxIndex(), 2), p.Insert("")
-			Loop, % p.MaxIndex()//2
+			Loop p.MaxIndex()//2
 				this[p[A_Index*2-1]] := p[A_Index*2]
 		}
 
@@ -190,14 +190,15 @@ class JSON
 		Remove(k) { ; restrict to single key
 			if !ObjHasKey(this, k), return
 			for i, v in this._
-				if (v = k), break
-			this._.Remove(i)
+				idx := i
+			until (v = k)
+			this._.Remove(idx)
 			if k is 'integer', return ObjRemove(this, k, "")
 			return ObjRemove(this, k)
 		}
 
 		len() {
-			return this._.MaxIndex()
+			return (this._.MaxIndex() || 0)
 		}
 
 		stringify(i:="") {

--- a/JSON.ahk
+++ b/JSON.ahk
@@ -18,7 +18,7 @@ class JSON
 			while (j:=InStr(src, '"',, j+1)) {
 				str := SubStr(src, i+1, j-i-1)
 				str := StrReplace(str, "\\", "\u005C")
-				if (SubStr(str, 0) != "\")
+				if (SubStr(str, -1) != "\")
 					break
 			}
 			src := SubStr(src, 1, i-1) . SubStr(src, j)

--- a/JSON.ahk
+++ b/JSON.ahk
@@ -187,14 +187,32 @@ class JSON
 			return this[k] := v
 		}
 
-		Remove(k) { ; restrict to single key
-			if !ObjHasKey(this, k), return
-			for i, v in this._
-				idx := i
-			until (v = k)
-			this._.Remove(idx)
-			if k is 'integer', return ObjRemove(this, k, "")
-			return ObjRemove(this, k)
+		Remove(k*) {
+			ascs := A_StringCaseSense
+			A_StringCaseSense := 'Off'
+			if (k.MaxIndex() > 1) {
+				k1 := k[1], k2 := k[2], is_int := false
+				if k1 is 'integer' && k2 is 'integer'
+					k1 := Round(k1), k2 := Round(k2), is_int := true
+				while true {
+					for each, key in this._
+						i := each
+					until found:=(key >= k1 && key <= k2)
+					if !found, break
+					key := this._.Remove(i)
+					ObjRemove(this, (is_int ? [key, ''] : [key])*)
+					res := A_Index
+				}
+			
+			} else for each, key in this._ {
+				if (key = (k.MaxIndex() ? k[1] : ObjMaxIndex(this))) {
+					key := this._.Remove(each)
+					res := ObjRemove(this, (key is 'integer' ? [key, ''] : [key])*)
+					break
+				}
+			}
+			A_StringCaseSense := ascs
+			return res
 		}
 
 		len() {

--- a/JSON.ahk
+++ b/JSON.ahk
@@ -1,6 +1,28 @@
 class JSON
 {
+	static _object := {} ;// object(s)/'{}' are derived from this -> no special behavior
+	static _array := [] ;// array(s)/'[]' are derived from this -> no special behavior
+	/* If 'OutputNormal' class property is set to true, object(s)/array(s) and
+	 * their descendants are returned as normal AHK object(s). Otherwise,
+	 * they're wrapped as instance(s) of JSON.object and JSON.array.
+	 */
+	static OutputNormal := true
+
 	parse(src) {
+		;// Pre-validate JSON source before parsing
+		if ((src:=Trim(src, " `t`n`r")) == "") ;// trim whitespace(s)
+			throw Exception('Empty JSON source.')
+		first := SubStr(src, 1, 1), last := SubStr(src, -1)
+		if !InStr('{["tfn0123456789-', first) ;// valid beginning chars
+		|| !InStr('}]el0123456789"', last) ;// valid ending chars
+		|| (first == '{' && last != '}') ;// if starts w/ '{' must end w/ '}'
+		|| (first == '[' && last != ']') ;// if starts w/ '[' must end w/ ']'
+		|| (first == '"' && last != '"') ;// if starts w/ '"' must end w/ '"'
+		|| (first == 'n' && last != 'l') ;// assume 'null'
+		|| (InStr('tf', first) && last != 'e') ;// assume 'true' OR 'false'
+		|| (InStr('-0123456789', first) && !(last is 'number')) ;// number
+			throw Exception('Invalid JSON format.', -1)
+		
 		esc_char := {
 		(Q
 			'"': '"',
@@ -11,7 +33,7 @@ class JSON
 			'r': '`r',
 			't': '`t'
 		)}
-		null := ""
+		;// Extract string literals
 		i := 0, strings := []
 		while (i:=InStr(src, '"',, i+1)) {
 			j := i
@@ -21,6 +43,7 @@ class JSON
 				if (SubStr(str, -1) != "\")
 					break
 			}
+			if !j, throw Exception("Missing close quote(s).", -1)
 			src := SubStr(src, 1, i-1) . SubStr(src, j)
 			z := 0
 			while (z:=InStr(str, "\",, z+1)) {
@@ -36,77 +59,100 @@ class JSON
 			}
 			strings.Insert(str)
 		}
-		pos := 1, ch := " "
-		key := dummy := []
-		stack := [result:=new JSON.array], assert := '{["tfn0123456789-'
-		while (ch != "") {
-			ch := SubStr(src, pos, 1), pos += 1
+		;// Check for missing opening/closing brace(s)
+		if InStr(src, '{') || InStr(src, '}') {
+			StrReplace(src, '{', '{', c1), StrReplace(src, '}', '}', c2)
+			if (c1 != c2), throw Exception("
+			(LTrim Q
+			Missing %Abs(c1-c2)% %(c1 > c2 ? 'clos' : 'open')%ing brace(s)
+			)", -1)
+		}
+		;// Check for missing opening/closing bracket(s)
+		if InStr(src, '[') || InStr(src, ']') {
+			StrReplace(src, '[', '[', c1), StrReplace(src, ']', ']', c2)
+			if (c1 != c2), throw Exception("
+			(LTrim Q
+			Missing %Abs(c1-c2)% %(c1 > c2 ? 'clos' : 'open')%ing bracket(s)
+			)", -1)
+		}
+		/* Determine whether to subclass objects/arrays as JSON.object and
+		 * JSON.array. The user can set this setting via the JSON.OutputNormal
+		 * class property.
+		 */
+		if this.OutputNormal, (_object := this._object, _array := this._array)
+		else (_object := this.object, _array := this.array)
+		pos := 0
+		, key := dummy := []
+		, stack := [result := []]
+		, assert := "" ;// assert := '{["tfn0123456789-'
+		, null := ""
+		;// Begin recursive descent
+		while ((ch := SubStr(src, ++pos, 1)) != "") {
+			;// skip whitespace
 			while (ch != "" && InStr(" `t`n`r", ch))
-				ch := SubStr(src, pos, 1), pos += 1
+				ch := SubStr(src, ++pos, 1)
+			;// check if current char is expected or not
 			if (assert != "") {
 				if !InStr(assert, ch), throw Exception("Unexpected '%ch%'", -1)
 				assert := ""
 			}
 
-			if InStr(":,", ch) {
-				assert := '{["tfn0123456789-'
-				continue
-			}
-
-			if InStr("{[", ch) { ; object|array - opening
-				cont := stack[1], base := (ch == '{' ? 'object' : 'array')
-				len := (ObjMaxIndex(cont) || 0)
-				stack.Insert(1, cont[key == dummy ? len+1 : key] := new JSON[base])
-				key := dummy
-				assert := (ch == '{' ? '"}' : ']{["tfn0123456789-')
-				continue
+			if InStr(":,", ch) { ;// colon(s) and comma(s)
+				;// no container object
+				if (cont == result), throw Exception("
+				(LTrim
+				Unexpected '%ch%' -> there is no container object/array.
+				)")
+				assert := '"'
+				if (ch == ':' || !(cont is _object)), assert .= '{[tfn0123456789-'
 			
-			} else if InStr("}]", ch) { ; object|array - closing
-				stack.Remove(1), assert := ']},'
-				continue
+			} else if InStr("{[", ch) { ;// object|array - opening
+				cont := stack[1]
+				, sub := new (ch == '{' ? _object : _array)
+				, stack.Insert(1, cont[key == dummy ? (ObjMaxIndex(cont) || 0)+1 : key] := sub)
+				, assert := (ch == '{' ? '"}' : ']{["tfn0123456789-')
+				if (key != dummy), key := dummy
 			
-			} else if (ch == '"') { ; string
+			} else if InStr("}]", ch) { ;// object|array - closing
+				stack.Remove(1), cont := stack[1]
+				, assert := cont is _object ? '},' : '],'
+			
+			} else if (ch == '"') { ;// string
 				str := strings.Remove(1), cont := stack[1]
 				if (key == dummy) {
-					if cont is JSON.array {
+					if (cont is _array || cont == result) {
 						key := (ObjMaxIndex(cont) || 0)+1
 					} else {
 						key := str, assert := ":"
 						continue
 					}
 				}
-				cont[key] := str, key := dummy
-				assert := ",%(cont is JSON.object ? '}' : ']')%"
-				continue
+				cont[key] := str
+				, assert := cont is _object ? '},' : '],'
+				, key := dummy
 			
-			} else if (ch >= 0 && ch <= 9) || (ch == "-") { ; number
+			} else if (ch >= 0 && ch <= 9) || (ch == "-") { ;// number
 				if !RegExMatch(src, "-?\d+(\.\d+)?((?i)E[-+]?\d+)?", num, pos-1)
 					throw Exception("Bad number", -1)
 				pos += StrLen(num.Value)-1
-				cont := stack[1], len := (ObjMaxIndex(cont) || 0)
-				cont[key == dummy ? len+1 : key] := num.Value+0 ; convert to pure number
-				key := dummy
-				assert := ",%(cont is JSON.object ? '}' : ']')%"
-				continue
+				, cont := stack[1]
+				, cont[key == dummy ? (ObjMaxIndex(cont) || 0)+1 : key] := num.Value+0
+				, assert := cont is _object ? '},' : '],'
+				if (key != dummy), key := dummy
 			
-			} else if InStr("tfn", ch, true) { ; true|false|null
+			} else if InStr("tfn", ch, true) { ;// true|false|null
 				val := {t:"true", f:"false", n:"null"}[ch]
-				; advance to next char, first char has already been validated
+				;// advance to next char, first char has already been validated
 				while (c:=SubStr(val, A_Index+1, 1)) {
-					ch := SubStr(src, pos, 1), pos += 1
-					if !(ch == c) ; case-sensitive comparison
+					ch := SubStr(src, ++pos, 1)
+					if !(ch == c) ;// case-sensitive comparison
 						throw Exception("Expected '%c%' instead of %ch%")
 				}
 
-				cont := stack[1], len := (ObjMaxIndex(cont) || 0)
-				cont[key == dummy ? len+1 : key] := Abs(%val%)
-				key := dummy
-				assert := ",%(cont is JSON.object ? '}' : ']')%"
-				continue
-			
-			} else {
-				if (ch != ""), throw Exception("Unexpected '%ch%'", -1)
-				else break
+				cont := stack[1]
+				, cont[key == dummy ? (ObjMaxIndex(cont) || 0)+1 : key] := Abs(%val%)
+				, assert := cont is _object ? '},' : '],'
+				if (key != dummy), key := dummy
 			}
 		}
 		return result[1]
@@ -115,8 +161,9 @@ class JSON
 	stringify(obj:="", i:="", lvl:=1) {
 		type := Type(obj)
 		if (type == "Object") {
-			if (obj is JSON.object || obj is JSON.array)
-				arr := obj is JSON.array
+			if (obj is JSON.object || obj is JSON.array
+			|| obj is JSON._object || obj is JSON._array)
+				arr := (obj is JSON.array || obj is JSON._array)
 			else for k in obj
 				if !(arr := (k == A_Index)), break
 			
@@ -129,10 +176,13 @@ class JSON
 				if IsObject(k) || (k == ""), throw Exception("Invalid key.", -1)
 				if !arr, key := k is 'number' ? '"%k%"' : JSON.stringify(k)
 				val := JSON.stringify(v, i, lvl)
-				s := ",%(n ? n : ' ') . t%"
-				str .= arr
-				? val . s
-				: "%key%:%((IsObject(v) && InStr(val, '{') == 1) ? n . t : ' ')%%val%%s%"
+				;// format output
+				str .= (arr ? "" : "
+				(LTrim Join Q C
+				%key%:%((IsObject(v) && InStr(val, '{') == 1) ;// if value is {}
+				? (n . t) ;// put opening '{' to next line, else OTB if '['
+				: (i ? ' ' : ''))% ;// put space after ':' if indented
+				)") . "%val%,%(n ? n : '') . t%" ;// value+comma+[newline+indent]
 			}
 			str := n . t . Trim(str, ",`n`t ") . n . SubStr(t, StrLen(i)+1)
 			return arr ? "[%str%]" : "{%str%}"
@@ -213,6 +263,16 @@ class JSON
 			}
 			A_StringCaseSense := ascs
 			return res
+		}
+
+		__Remove(k) { ; restrict to single key
+			if !ObjHasKey(this, k), return
+			for i, v in this._
+				idx := i
+			until (v = k)
+			this._.Remove(idx)
+			if k is 'integer', return ObjRemove(this, k, "")
+			return ObjRemove(this, k)
 		}
 
 		len() {

--- a/JSON.ahk
+++ b/JSON.ahk
@@ -1,131 +1,92 @@
-/*
-JSON module for AutoHotkey [requires v.1.1+, tested on v.1.1.13.01]
-
-The parser is inspired by Douglas Crockford's(json.org) json_parse.js and
-and Mike Samuel's json_sans_eval.js (https://code.google.com/p/json-sans-eval/).
-I've combined the two implementation to create a fast(somehow:P) and validating
-JSON parser. Some section(s) are based on VxE's JSON function(s) - 
-[http://www.ahkscript.org/boards/viewtopic.php?f=6&t=30] - Thank you VxE
-*/
 class JSON
 {
-	/*
-	Parses a string containing JSON string and returns it as an AHK object.
-	Objects {} and arrays [] are wrapped as JSON.object and JSON.array instances.
-	Objects {} key-value pairs are enumerated in the order they are created
-	instead of the default behavior -- alpahabetically. An exception is thrown
-	if the JSON string is badly formatted, e.g. illegal chars, invalid escaping
-	Usage:
-	--start-of-code--
-	j := JSON.parse("[{""foo"": ""Hello World"", ""bar"":""AutoHotkey""}]")
-	MsgBox, % j[1].foo ; displays 'Hello World'
-	MsgBox, % j[1].bar ; displays 'AutoHotkey'
-	--end-of-code--
-	*/
 	parse(src) {
 		esc_char := {
-		(Join
-			"""": """",
-			"/": "/",
-			"b": Chr(08),
-			"f": Chr(12),
-			"n": "`n",
-			"r": "`r",
-			"t": "`t"
+		(Q
+			'"': '"',
+			'/': '/',
+			'b': Chr(08),
+			'f': Chr(12),
+			'n': '`n',
+			'r': '`r',
+			't': '`t'
 		)}
-		null := "" ; needed??
-
-		/*
-		This loop is based on VxE's JSON_ToObj.ahk - thank you VxE
-		Quoted strings are extracted and temporarily stored in an object and
-		later on re-inserted while the result object is being created.
-		*/
+		null := ""
 		i := 0, strings := []
-		while (i:=InStr(src, """",, i+1)) {
+		while (i:=InStr(src, '"',, i+1)) {
 			j := i
-			while (j:=InStr(src, """",, j+1)) {
+			while (j:=InStr(src, '"',, j+1)) {
 				str := SubStr(src, i+1, j-i-1)
-				StringReplace, str, str, \\, \u005C, A
+				str := StrReplace(str, "\\", "\u005C")
 				if (SubStr(str, 0) != "\")
 					break
 			}
-
 			src := SubStr(src, 1, i-1) . SubStr(src, j)
-
 			z := 0
 			while (z:=InStr(str, "\",, z+1)) {
 				ch := SubStr(str, z+1, 1)
-				if InStr("""btnfr/", ch) ; esc_char.HasKey(ch)
+				if InStr('"btnfr/', ch)
 					str := SubStr(str, 1, z-1) . esc_char[ch] . SubStr(str, z+2)
-				
 				else if (ch = "u") {
 					hex := "0x" . SubStr(str, z+2, 4)
 					if !(A_IsUnicode || (Abs(hex) < 0x100))
-						continue ; throw Exception() ???
+						continue
 					str := SubStr(str, 1, z-1) . Chr(hex) . SubStr(str, z+6)
-				
 				} else throw Exception("Bad string")
 			}
 			strings.Insert(str)
 		}
-		
 		pos := 1, ch := " "
 		key := dummy := []
-		stack := [result:=new JSON.array], assert := "{[""tfn0123456789-"
-		while (ch != "", ch:=SubStr(src, pos, 1), pos+=1) {
-			
-			while (ch != "" && InStr(" `t`r`n", ch)) ; skip whitespace
+		stack := [result:=new JSON.array], assert := '{["tfn0123456789-'
+		while (ch != "") {
+			ch := SubStr(src, pos, 1), pos += 1
+			while (ch != "" && InStr(" `t`r`n", ch))
 				ch := SubStr(src, pos, 1), pos += 1
-				;pos := RegExMatch(src, "\S", ch, pos)+1
-			/*
-			Check if the current character is expected or not
-			Acts as a simple validator for badly formatted JSON string
-			*/
 			if (assert != "") {
-				if !InStr(assert, ch)
-					throw Exception("Unexpected '" . ch . "'", -1)
+				if !InStr(assert, ch), throw Exception("Unexpected '%ch%'", -1)
 				assert := ""
 			}
-			
+
 			if InStr(":,", ch) {
-				assert := "{[""tfn0123456789-"
+				assert := '{["tfn0123456789-'
 				continue
 			}
 
 			if InStr("{[", ch) { ; object|array - opening
-				cont := stack[1], base := (ch == "{" ? "object" : "array")
-				len := Round(ObjMaxIndex(cont))
-				stack.Insert(1, cont[key == dummy ? len+1 : key] := new JSON[base])
+				cnt := stack[1], base := (ch == '{' ? 'object' : 'array')
+				len := (ObjMaxIndex(cnt) || 0)
+				stack.Insert(1, cnt[key == dummy ? len+1 : key] := new JSON[base])
 				key := dummy
-				assert := (ch == "{" ? """}" : "]{[""tfn0123456789-")
+				assert := (ch == '{' ? '"}' : ']{["tfn0123456789-')
 				continue
 			
 			} else if InStr("}]", ch) { ; object|array - closing
-				stack.Remove(1), assert := "]},"
+				stack.Remove(1), assert := ']},'
 				continue
 			
-			} else if (ch == """") { ; string
-				str := strings.Remove(1), cont := stack[1]
+			} else if (ch == '"') { ; string
+				str := strings.Remove(1), cnt := stack[1]
 				if (key == dummy) {
-					if (cont.__Class == "JSON.array") {
-						key := Round(ObjMaxIndex(cont))+1
+					if cnt is JSON.array {
+						key := (ObjMaxIndex(cnt) || 0)+1
 					} else {
 						key := str, assert := ":"
 						continue
 					}
 				}
-				cont[key] := str, key := dummy
-				assert := "," . (cont.__Class == "JSON.object" ? "}" : "]")
+				cnt[key] := str, key := dummy
+				assert := ",%(cnt is JSON.object ? '}' : ']')%"
 				continue
 			
 			} else if (ch >= 0 && ch <= 9) || (ch == "-") { ; number
 				if !RegExMatch(src, "-?\d+(\.\d+)?((?i)E[-+]?\d+)?", num, pos-1)
 					throw Exception("Bad number", -1)
-				pos += StrLen(num)-1
-				cont := stack[1], len := Round(ObjMaxIndex(cont))
-				cont[key == dummy ? len+1 : key] := num
+				pos += StrLen(num.Value)-1
+				cnt := stack[1], len := (ObjMaxIndex(cnt) || 0)
+				cnt[key == dummy ? len+1 : key] := num.Value+0 ; convert to pure number
 				key := dummy
-				assert := "," . (cont.__Class == "JSON.object" ? "}" : "]")
+				assert := ",%(cnt is JSON.object ? '}' : ']')%"
 				continue
 			
 			} else if InStr("tfn", ch, true) { ; true|false|null
@@ -134,129 +95,82 @@ class JSON
 				while (c:=SubStr(val, A_Index+1, 1)) {
 					ch := SubStr(src, pos, 1), pos += 1
 					if !(ch == c) ; case-sensitive comparison
-						throw Exception("Expected '" c "' instead of " ch)
+						throw Exception("Expected '%c%' instead of %ch%")
 				}
 
-				cont := stack[1], len := Round(ObjMaxIndex(cont))
-				cont[key == dummy ? len+1 : key] := %val%
+				cnt := stack[1], len := (ObjMaxIndex(cnt) || 0)
+				cnt[key == dummy ? len+1 : key] := Abs(%val%)
 				key := dummy
-				assert := "," . (cont.__Class == "JSON.object" ? "}" : "]")
+				assert := ",%(cnt is JSON.object ? '}' : ']')%"
 				continue
 			
 			} else {
-				if (ch != "")
-					throw Exception("Unexpected '" . ch . "'", -1)
+				if (ch != ""), throw Exception("Unexpected '%ch%'", -1)
 				else break
 			}
 		}
 		return result[1]
 	}
-	/*
-	Returns a string representation of an AHK object.
-	The 'i' (indent) parameter allows 'pretty printing'. Specify any char(s)
-	to use as indentation.
-	Usage: JSON.stringify(object, "`t") ; use tab as indentation
-	       JSON.stringify(object, "    ") ; 4-spaces indentation
-	       JSON.stringify(object) ; no indentation
-	Remarks:
-	JSON.object and JSON.array instance(s) may call this method, automatically
-	passing itself as the first parameter. If indententation is specified,
-	nested arrays [] are in OTB-style.
-	As per JSON spec, hex numbers are treated as strings - doing something
-	like: 'JSON.stringify([0xffff])' will output '0xffff' as decimal. To
-	output as string, wrap it in quotes: 'JSON.stringify(["0xffff"])'
-	0, 1 and ""(blank) are output as false, true and null respectively.
- 	*/
-	stringify(obj:="", i:="", lvl:=1) {
-		if IsObject(obj) {
-			if (ComObjValue(x) != "") ; COM Object
-				throw Exception("COM Object(s) are not supported.")
-			if (obj.base == JSON.object || obj.base == JSON.array)
-				arr := (obj.base == JSON.array ? true : false)
-			else for k in obj
-				arr := (k == A_Index)
-			until !arr
 
+	stringify(obj:="", i:="", lvl:=1) {
+		type := Type(obj)
+		if (type == "Object") {
+			if (obj is JSON.object || obj is JSON.array)
+				arr := obj is JSON.array
+			else for k in obj
+				if !(arr := (k == A_Index)), break
+			
 			n := i ? "`n" : (i:="", t:="")
 			Loop, % i ? lvl : 0
 				t .= i
-
+			
 			lvl += 1
 			for k, v in obj {
-				if IsObject(k) || (k == "")
-					throw Exception("Invalid key.", -1)
-				if !arr
-					; integer key(s) are automatically wrapped in quotes
-					key := k+0 == k ? """" . k . """" : JSON.stringify(k)
+				if IsObject(k) || (k == ""), throw Exception("Invalid key.", -1)
+				if !arr, key := k is 'number' ? '"%k%"' : JSON.stringify(k)
 				val := JSON.stringify(v, i, lvl)
-				s := "," . (n ? n : " ") . t
-				str .= arr ? (val . s)
-				           : key . ":" . ((IsObject(v) && InStr(val, "{") == 1) ? n . t : " ") . val . s
+				s := ",%(n ? n : ' ') . t%"
+				str .= arr
+				? val . s
+				: "%key%:%((IsObject(v) && InStr(val, '{') == 1) ? n . t : ' ')%%val%%s%"
 			}
 			str := n . t . Trim(str, ",`n`t ") . n . SubStr(t, StrLen(i)+1)
-			return arr ? "[" str "]" : "{" str "}"
-		}
-		; true|false|null
-		else if InStr(01, obj) || (obj == "")
-			return {"": "null", 0:"false", 1:"true"}[obj]
-		; String
-		else if [obj].GetCapacity(1) {
-			if obj is float
-				return obj
-
-			esc_char := {
-			(Join
-			    """": "\""",
-			    "/": "\/",
-			    Chr(08): "\b",
-			    Chr(12): "\f",
-			    "`n": "\n",
-			    "`r": "\r",
-			    "`t": "\t"
-			)}
-			
-			StringReplace, obj, obj, \, \\, A
-			for k, v in esc_char
-				StringReplace, obj, obj, % k, % v, A
-
-			while RegExMatch(obj, "[^\x20-\x7e]", ch) {
-				ustr := Asc(ch), esc_ch := "\u", n := 12
-				while (n >= 0)
-					esc_ch .= Chr((x:=(ustr>>n) & 15) + (x<10 ? 48 : 55))
-					, n -= 4
-				StringReplace, obj, obj, % ch, % esc_ch, A
-			}
-			return """" . obj . """"
-		}
-		; Number
-		if obj is xdigit
-			if obj is not digit
-				obj := """" . obj . """"
+			return arr ? "[%str%]" : "{%str%}"
 		
-		return obj
+		} else if (type == "Integer" || type == "Float") {
+			return InStr('01', obj) ? (obj ? 'true' : 'false') : obj
+		
+		} else if (type == "String") {
+			if (obj == ""), return 'null'
+			esc_char := {
+			(Q
+				'"': '\"',
+				'/': '\/',
+				Chr(08): '\b',
+				Chr(12): '\f',
+				'`n': '\n',
+				'`r': '\r',
+				'`t': '\t'
+			)}
+			obj := StrReplace(obj, "\", "\\")
+			for k, v in esc_char
+				obj := StrReplace(obj, k, v)
+			while RegExMatch(obj, "[^\x20-\x7e]", ch) {
+				ustr := Ord(ch.Value), esc_ch := "\u", n := 12
+				while (n >= 0)
+					esc_ch .= Chr((x:=(ustr>>n) & 15) + (x<10 ? 48 : 55)), n -= 4
+				obj := StrReplace(obj, ch.Value, esc_ch)
+			}
+			return '"%obj%"'
+		}
+		throw Exception("Unsupported type: '%type%'")
 	}
-	/*
-	Base object for objects {} created during parsing. The user may also manually
-	create an insatnce of this class. The sole purpose of wrapping objects {} as
-	JSON.object instance is to allow enumeration of key-value pairs in the order
-	they were created. The len() method may be used to get the total count of
-	key-value pairs.
-	Usage: Instances are automatically created during parsing. The user may
-	       use the 'new' operator to create a JSON.object object manually.
-	--start-of-code--
-	obj := new JSON.object("key1", "value1", "key2", "value2")
-	obj["key3"] := "Add a new key-value pair"
-	MsgBox, % obj.stringify() ; display as string
-	; '{"key1": "value1", "key2": "value2", "key3": "Add a new key-value pair"}'
-	--end-of-code--
-	*/
+
 	class object
 	{
-		
 		__New(p*) {
 			ObjInsert(this, "_", [])
-			if Mod(p.MaxIndex(), 2)
-				p.Insert("")
+			if Mod(p.MaxIndex(), 2), p.Insert("")
 			Loop, % p.MaxIndex()//2
 				this[p[A_Index*2-1]] := p[A_Index*2]
 		}
@@ -274,14 +188,11 @@ class JSON
 		}
 
 		Remove(k) { ; restrict to single key
-			if !ObjHasKey(this, k)
-				return
+			if !ObjHasKey(this, k), return
 			for i, v in this._
-				continue
-			until (v = k)
+				if (v = k), break
 			this._.Remove(i)
-			if k is integer
-				return ObjRemove(this, k, "")
+			if k is 'integer', return ObjRemove(this, k, "")
 			return ObjRemove(this, k)
 		}
 
@@ -295,25 +206,20 @@ class JSON
 
 		class Enum
 		{
-
 			__New(obj) {
 				this.obj := obj
 				this.enum := obj._._NewEnum()
 			}
 			; Lexikos' ordered array workaround
 			Next(ByRef k, ByRef v:="") {
-				if (r:=this.enum.Next(i, k))
-					v := this.obj[k]
+				if (r:=this.enum.Next(i, k)), v := this.obj[k]
 				return r
 			}
 		}
 	}
-	/*
-	Base object for arrays [] created during parsing. Same as JSON.object above.
-	*/	
+
 	class array
 	{
-			
 		__New(p*) {
 			for k, v in p
 				this.Insert(v)

--- a/JSON.ahk
+++ b/JSON.ahk
@@ -192,11 +192,10 @@ class JSON
 		}
 
 		else if (type == "Integer" || type == "Float")
-			return InStr("01", obj) ? (obj ? "true" : "false") : obj
+			return obj
 
 		else if (type == "String")
 		{
-			if (obj == ""), return null := "null" ;// compensate for v2.0-a049 bug
 			static esc_seq := {
 			(Q
 				'"': '\"',
@@ -207,15 +206,18 @@ class JSON
 				'`r': '\r',
 				'`t': '\t'
 			)}
-			obj := StrReplace(obj, "\", "\\")
-			for k, v in esc_seq
-				obj := StrReplace(obj, k, v)
-			while RegExMatch(obj, "[^\x20-\x7e]", wstr)
+			if (obj != "")
 			{
-				ucp := Ord(wstr.Value), hex := "\u", n := 16
-				while ((n -= 4) >= 0)
-					hex .= Chr( (x := (ucp >> n) & 15) + (x < 10 ? 48 : 55) )
-				obj := StrReplace(obj, wstr.Value, hex)
+				obj := StrReplace(obj, "\", "\\")
+				for k, v in esc_seq
+					obj := StrReplace(obj, k, v)
+				while RegExMatch(obj, "[^\x20-\x7e]", wstr)
+				{
+					ucp := Ord(wstr.Value), hex := "\u", n := 16
+					while ((n -= 4) >= 0)
+						hex .= Chr( (x := (ucp >> n) & 15) + (x < 10 ? 48 : 55) )
+					obj := StrReplace(obj, wstr.Value, hex)
+				}
 			}
 			return '"%obj%"'
 		}

--- a/JSON.ahk
+++ b/JSON.ahk
@@ -5,8 +5,8 @@ class JSON
 		(Q
 			'"': '"',
 			'/': '/',
-			'b': Chr(08),
-			'f': Chr(12),
+			'b': '`b',
+			'f': '`f',
 			'n': '`n',
 			'r': '`r',
 			't': '`t'
@@ -41,7 +41,7 @@ class JSON
 		stack := [result:=new JSON.array], assert := '{["tfn0123456789-'
 		while (ch != "") {
 			ch := SubStr(src, pos, 1), pos += 1
-			while (ch != "" && InStr(" `t`r`n", ch))
+			while (ch != "" && InStr(" `t`n`r", ch))
 				ch := SubStr(src, pos, 1), pos += 1
 			if (assert != "") {
 				if !InStr(assert, ch), throw Exception("Unexpected '%ch%'", -1)
@@ -146,8 +146,8 @@ class JSON
 			(Q
 				'"': '\"',
 				'/': '\/',
-				Chr(08): '\b',
-				Chr(12): '\f',
+				'`b': '\b',
+				'`f': '\f',
 				'`n': '\n',
 				'`r': '\r',
 				'`t': '\t'

--- a/JSON.ahk
+++ b/JSON.ahk
@@ -54,9 +54,9 @@ class JSON
 			}
 
 			if InStr("{[", ch) { ; object|array - opening
-				cnt := stack[1], base := (ch == '{' ? 'object' : 'array')
-				len := (ObjMaxIndex(cnt) || 0)
-				stack.Insert(1, cnt[key == dummy ? len+1 : key] := new JSON[base])
+				cont := stack[1], base := (ch == '{' ? 'object' : 'array')
+				len := (ObjMaxIndex(cont) || 0)
+				stack.Insert(1, cont[key == dummy ? len+1 : key] := new JSON[base])
 				key := dummy
 				assert := (ch == '{' ? '"}' : ']{["tfn0123456789-')
 				continue
@@ -66,27 +66,27 @@ class JSON
 				continue
 			
 			} else if (ch == '"') { ; string
-				str := strings.Remove(1), cnt := stack[1]
+				str := strings.Remove(1), cont := stack[1]
 				if (key == dummy) {
-					if cnt is JSON.array {
-						key := (ObjMaxIndex(cnt) || 0)+1
+					if cont is JSON.array {
+						key := (ObjMaxIndex(cont) || 0)+1
 					} else {
 						key := str, assert := ":"
 						continue
 					}
 				}
-				cnt[key] := str, key := dummy
-				assert := ",%(cnt is JSON.object ? '}' : ']')%"
+				cont[key] := str, key := dummy
+				assert := ",%(cont is JSON.object ? '}' : ']')%"
 				continue
 			
 			} else if (ch >= 0 && ch <= 9) || (ch == "-") { ; number
 				if !RegExMatch(src, "-?\d+(\.\d+)?((?i)E[-+]?\d+)?", num, pos-1)
 					throw Exception("Bad number", -1)
 				pos += StrLen(num.Value)-1
-				cnt := stack[1], len := (ObjMaxIndex(cnt) || 0)
-				cnt[key == dummy ? len+1 : key] := num.Value+0 ; convert to pure number
+				cont := stack[1], len := (ObjMaxIndex(cont) || 0)
+				cont[key == dummy ? len+1 : key] := num.Value+0 ; convert to pure number
 				key := dummy
-				assert := ",%(cnt is JSON.object ? '}' : ']')%"
+				assert := ",%(cont is JSON.object ? '}' : ']')%"
 				continue
 			
 			} else if InStr("tfn", ch, true) { ; true|false|null
@@ -98,10 +98,10 @@ class JSON
 						throw Exception("Expected '%c%' instead of %ch%")
 				}
 
-				cnt := stack[1], len := (ObjMaxIndex(cnt) || 0)
-				cnt[key == dummy ? len+1 : key] := Abs(%val%)
+				cont := stack[1], len := (ObjMaxIndex(cont) || 0)
+				cont[key == dummy ? len+1 : key] := Abs(%val%)
 				key := dummy
-				assert := ",%(cnt is JSON.object ? '}' : ']')%"
+				assert := ",%(cont is JSON.object ? '}' : ']')%"
 				continue
 			
 			} else {

--- a/JSON.ahk
+++ b/JSON.ahk
@@ -132,7 +132,7 @@ class JSON
 				, key := dummy
 			
 			} else if (ch >= 0 && ch <= 9) || (ch == "-") { ;// number
-				if !RegExMatch(src, "-?\d+(\.\d+)?((?i)E[-+]?\d+)?", num, pos-1)
+				if !RegExMatch(src, "-?\d+(\.\d+)?((?i)E[-+]?\d+)?", num, pos)
 					throw Exception("Bad number", -1)
 				pos += StrLen(num.Value)-1
 				, cont := stack[1]


### PR DESCRIPTION
Hi CocoBelgica,

I experimented your Jxon function, thanks for creating it.
I was wondering if I could use it with JSON navigation strings stored in an ini file.

If for example my code is :
/*
   [JSON]   ; .INI File
   Key1=hello
   Key2=foo.1
   Key3=its.over
*/
	json_str = {"hello":"world","its":{"over":"9000"},"foo":["bar"]}
	j := Jxon_Load(json_str)
	msgbox % j.hello			; test1-1 ok
		msgbox % j["hello"]		; (using Key1 equivalent of the above) : test1-2 ok
	msgbox % j.foo.1			; ok
	msgbox % j.foo[1]			; test2-1 ok
		;msgbox % 				; (using Key2 equivalent of the above) : test2-2 ?
	msgbox % j.its.over			; test3-1 ok
		;msgbox % 				; (using Key3 equivalent of the above) : test3-2 ?

What would be the equivalent syntax for test2-2 and test3-2 based on test1-2 syntax ?

Thanks in advance.
Best regards.