### PR TITLE
[JSON.ahk] Convert 'Loop %' to 'while', v2 a100 compatible

### DIFF
--- a/JSON.ahk
+++ b/JSON.ahk
@@ -50,9 +50,9 @@ class JSON
 			this.keys := this.rev ? {} : false
 
 			static quot := Chr(34), bashq := "\" . quot
-			     , json_value := quot . "{[01234567890-tfn"
-			     , json_value_or_array_closing := quot . "{[]01234567890-tfn"
-			     , object_key_or_object_closing := quot . "}"
+				 , json_value := quot . "{[01234567890-tfn"
+				 , json_value_or_array_closing := quot . "{[]01234567890-tfn"
+				 , object_key_or_object_closing := quot . "}"
 
 			key := ""
 			is_key := false
@@ -180,15 +180,15 @@ class JSON
 			col := pos - InStr(text, "`n",, -(StrLen(text)-pos+1))
 			msg := Format("{1}`n`nLine:`t{2}`nCol:`t{3}`nChar:`t{4}"
 			,     (expect == "")     ? "Extra data"
-			    : (expect == "'")    ? "Unterminated string starting at"
-			    : (expect == "\")    ? "Invalid \escape"
-			    : (expect == ":")    ? "Expecting ':' delimiter"
-			    : (expect == quot)   ? "Expecting object key enclosed in double quotes"
-			    : (expect == qurly)  ? "Expecting object key enclosed in double quotes or object closing '}'"
-			    : (expect == ",}")   ? "Expecting ',' delimiter or object closing '}'"
-			    : (expect == ",]")   ? "Expecting ',' delimiter or array closing ']'"
-			    : InStr(expect, "]") ? "Expecting JSON value or array closing ']'"
-			    :                      "Expecting JSON value(string, number, true, false, null, object or array)"
+				: (expect == "'")    ? "Unterminated string starting at"
+				: (expect == "\")    ? "Invalid \escape"
+				: (expect == ":")    ? "Expecting ':' delimiter"
+				: (expect == quot)   ? "Expecting object key enclosed in double quotes"
+				: (expect == qurly)  ? "Expecting object key enclosed in double quotes or object closing '}'"
+				: (expect == ",}")   ? "Expecting ',' delimiter or object closing '}'"
+				: (expect == ",]")   ? "Expecting ',' delimiter or array closing ']'"
+				: InStr(expect, "]") ? "Expecting JSON value or array closing ']'"
+				:                      "Expecting JSON value(string, number, true, false, null, object or array)"
 			, line, col, pos)
 
 			static offset := A_AhkVersion<"2" ? -3 : -4
@@ -236,8 +236,11 @@ class JSON
 			if (space) {
 				static integer := "integer"
 				if space is %integer%
-					Loop, % ((n := Abs(space))>10 ? 10 : n)
+				{
+					n := ((n := Abs(space)) > 10) ? 10 : n
+					while (A_Index <= n)
 						this.gap .= " "
+				}
 				else
 					this.gap := SubStr(space, 1, 10)
 
@@ -276,7 +279,8 @@ class JSON
 
 					str := ""
 					if (is_array) {
-						Loop, % value.Length() {
+						n := value.Length()
+						while (A_Index <= n) {
 							if (this.gap)
 								str .= this.indent
 							


### PR DESCRIPTION
Instances of `Loop %` have been converted to `while` loops .

- v1 1.1.30.1 compatible
- v2 a100 compatible