### PR TITLE
fix error when float/double numbers are passed

### DIFF
--- a/Jxon.ahk
+++ b/Jxon.ahk
@@ -188,7 +188,8 @@ Jxon_Dump(obj, indent:="", lvl:=1)
 	}
 
 	; Number
-	else if (ObjGetCapacity([obj], 1) == "")
+	else if obj is number
+	; else if (ObjGetCapacity([obj], 1) == "")
 		return obj
 
 	; String (null -> not supported by AHK)


### PR DESCRIPTION
hlConfig := {showInfo     : chrome.Jxon_True()
                   ,contentColor : {r:0, g:100, b:0, a:0.5}} <-- float parameter for alpha channel

when sending information as shown above Jxon_Dump passes "0.5" instead of unquoted value.
That's because float/doubles in autohotkey have a string buffer attached to them, and tricks your function in to not sending the parameter as is.